### PR TITLE
Bug/texts revision

### DIFF
--- a/UXperience/ViewModel/Model/Base.lproj/laws.json
+++ b/UXperience/ViewModel/Model/Base.lproj/laws.json
@@ -2,7 +2,7 @@
     {
         "categoria":"heurística",
         "titulo":"Efeito de Usabilidade Estética",
-        "resumo":"Um design agradável cria uma resposta positiva no cérebro das pessoas e as leva a acreditar que o design realmente funciona melhor. As pessoas são mais tolerantes com pequenos problemas de usabilidade quando o design de um produto ou serviço tem uma estética agradável. O design visualmente agradável pode esconder problemas de usabilidade e evitar que problemas sejam descobertos durante o teste de usabilidade.  A usabilidade e a estética são os dois fatores mais importantes na avaliação da experiência geral do usuário para um aplicativo. Elas são julgadas pelas expectativas de reutilização de um usuário e, em seguida, seu julgamento final pós-uso ou experiente.",
+        "resumo":"Um design agradável cria uma resposta positiva no cérebro das pessoas e as leva a crer que o produto ou serviço funciona melhor. As pessoas são mais tolerantes com pequenos problemas de usabilidade quando o design tem uma estética agradável. Um design visualmente agradável pode esconder problemas e até evitar que eles sejam descobertos durante testes. Usabilidade e estética são os dois fatores mais importantes na avaliação da experiência geral da pessoa que usa um aplicativo. Elas são avaliadas tanto pelas expectativas de reutilização do app quanto pelo julgamento final sobre ele, seja este um julgamento experiente ou apenas uma opinião pós-uso.",
         "leiaMais":"https://www.nngroup.com/articles/aesthetic-usability-effect/",
         "asset":"Efeito_de_Usabilidade_Estetica",
         "exemplo":"usabilidadeEstética",
@@ -10,8 +10,8 @@
     },
     {
         "categoria":"heurística",
-        "titulo":"Lei de Fitt's",
-        "resumo":"Os alvos de toque devem ser grandes o suficiente para que os usuários os selecionem com precisão. Eles devem ter amplo espaçamento entre eles, assim como devem ser colocados em áreas de fácil acesso. À medida que você cria novos designs de interface do usuário, pense em otimizar a distância e o tamanho ​​criando alvos grandes, bem espaçados e posicionando-os de modo que fiquem próximos da localização anterior mais provável para o usuário.",
+        "titulo":"Lei de Fitt",
+        "resumo":"Os alvos de toque em uma interface devem ser grandes o suficiente para que qualquer pessoa consiga selecioná-los com precisão. Devem ser colocados em áreas de fácil acesso e deve haver um amplo espaçamento entre eles. À medida em que você cria novos designs de interface, pense em otimizar a distância e o tamanho dos elementos ​​criando alvos grandes, bem espaçados e posicionados de modo que fiquem próximos da localização do dedo ou cursor da pessoa que está usando seu app. Boas práticas em interfaces incluem evitar aglomerações de alvos, usar alvos grandes, escolher ícones seguidos de legenda e criar alvos bastante amplos sempre que possível.",
         "leiaMais":"https://www.nngroup.com/articles/fitts-law/",
         "asset":"Lei_De_Fitts",
         "exemplo":"fitts",
@@ -19,8 +19,8 @@
     },
     {
         "categoria":"heurística",
-        "titulo":"Efeito Gradiente de Objectivos",
-        "resumo":"A tendência de se aproximar de um objetivo aumenta com a proximidade do objetivo.Quanto mais próximos os usuários estiverem de concluir uma tarefa, mais rápido eles trabalharão para alcançá-la. Fornecer a sensação de progresso em direção a uma meta ajudará a garantir que os usuários tenham mais motivação para concluir essa tarefa. Forneça uma indicação clara do progresso para motivar os usuários a concluir as tarefas.",
+        "titulo":"Efeito Gradiente de Objetivos",
+        "resumo":"O entusiasmo para atingirmos um objetivo aumenta na medida em que nos aproximamos dele. Quanto mais próximas as pessoas que utilizam seu produto estiverem de concluir uma tarefa, mais rápido elas se esforçarão para terminá-la. Fornecer a sensação de progresso em direção a uma meta ajudará a garantir que as pessoas tenham mais motivação para alcançá-la. Forneça indicações claras do progresso de tarefas ou mostre cada passo do processo enquanto a pessoa usuária espera por algo.",
         "leiaMais":"https://medium.com/choice-hacking/how-uber-uses-psychology-to-perfect-their-customer-experience-d6c440285029",
         "asset":"Efeito_De_Nivel_De_Gradiente",
         "exemplo":"gradiente",
@@ -28,8 +28,8 @@
     },
     {
         "categoria":"heurística",
-        "titulo":"Lei de Hick`s",
-        "resumo":"O tempo que leva para tomar uma decisão aumenta com o número e a complexidade das escolhas. Diminua as opções de escolha quando o tempo de resposta for curto, quebre uma tarefa grande em várias pequenas, evite sobrecarregar os usuários destacando as opções recomendadas. Tenha cuidado para não simplificar demais e chegar ao ponto do usuário não entender. Às vezes, não há como evitar a complexidade, quando temos uma grande quantidade de informações necessárias. O objetivo da Lei de Hick é tentar simplificar o processo de tomada de decisão, não eliminá -lo totalmente.",
+        "titulo":"Lei de Hick",
+        "resumo":"O tempo que leva para tomar uma decisão aumenta com o número e a complexidade das escolhas. Quando o tempo para resposta for curto, diminua as opções de escolha ou quebre uma tarefa grande em várias pequenas. Você pode também destacar as opções recomendadas para não sobrecarregar as pessoas que usam seu produto. Mas tenha cuidado para não simplificar demais até chegar ao ponto de deixar a interface difícil de entender. Às vezes, quando temos uma grande quantidade de informações necessárias, não há como evitar a complexidade. O objetivo da Lei de Hick é tentar simplificar o processo de tomada de decisão, não eliminá-lo totalmente.",
         "leiaMais":"https://medium.com/choice-hacking/choice-overload-why-simplicity-is-the-key-to-winning-customers-2f8e239eaba6",
         "asset":"Lei_De_Hick",
         "exemplo":"hicklaw",
@@ -38,7 +38,7 @@
     {
         "categoria":"heurística",
         "titulo":"Lei de Jakob",
-        "resumo":"Os usuários passam a maior parte do tempo em outros sites. Isso significa que os usuários preferem que seu site funcione da mesma forma que os outros funcionam. Os usuários vão transferir as expectativas que construíram em torno de um produto familiar para outro que pareça semelhante. Ao alavancar os modelos mentais existentes, podemos criar experiências de usuário superiores nas quais os usuários podem se concentrar em suas tarefas em vez de aprender novos modelos. Ao fazer alterações, minimize as diferenças, capacitando os usuários a continuar usando uma versão familiar por um tempo limitado.",
+        "resumo":"As pessoas que usam seu produto passam a maior parte do tempo em outros sites, usando produtos que não são o seu. Isso significa que elas preferem que o seu serviço funcione da mesma forma que os outros. Transferimos expectativas que construímos em torno de um produto familiar para outro que nos parece semelhante. Ao promover modelos mentais já existentes, criamos experiências de uso superiores, nas quais as pessoas podem se concentrar em suas tarefas em vez de aprender novos modelos. Ao fazer alterações, minimize as diferenças e dê a chance para quem usa seu produto de continuar usando uma versão familiar por um tempo limitado, por exemplo.",
         "leiaMais":"https://www.nngroup.com/articles/top-10-mistakes-web-design/",
         "asset":"Lei_De_Jakob",
         "exemplo":"jakob",
@@ -46,8 +46,8 @@
     },
     {
         "categoria":"heurística",
-        "titulo":"Lei de Miller's",
-        "resumo":"Qualquer elemento que não esteja ajudando o usuário a atingir seu objetivo está trabalhando contra ele. Lembre-se de que a capacidade de memória de curto prazo varia de pessoa para pessoa, com base em seu conhecimento prévio e contexto situacional. Organize o conteúdo em partes menores para ajudar os usuários a processar, entender e memorizar facilmente. Embora a carga cognitiva não seja totalmente evitável, os designers devem se esforçar para gerenciar e acomodar esses limites.",
+        "titulo":"Lei de Miller",
+        "resumo":"Qualquer elemento que não esteja ajudando a pessoa usuária a atingir seu objetivo está trabalhando contra ela. Lembre-se de que a capacidade de memória de curto prazo varia de pessoa para pessoa, com base em seu contexto e conhecimento prévio. Organize o conteúdo em partes menores para ajudar as pessoas que usam seu produto a processar, entender e memorizar informações facilmente. Embora a carga cognitiva nunca seja completamente, designers devem se esforçar para gerenciar e acomodar esses limites.",
         "leiaMais":"https://blog.prototypr.io/design-principles-for-reducing-cognitive-load-84e82ca61abd",
         "asset":"Lei_De_Miller",
         "exemplo":"miller",
@@ -55,8 +55,8 @@
     },
     {
         "categoria":"heurística",
-        "titulo":"Lei de Parkinson`s",
-        "resumo":"Limite o tempo que leva para concluir uma tarefa ao que os usuários esperam que ela leve. Um grande grupo pode conter apenas alguns contribuintes significativos para o resultado desejado. Recursos como preenchimento automático para economizar tempo do usuário ao fornecer informações críticas nos formulários. Isso permite a conclusão rápida de compras, reservas e outras funções semelhantes, evitando a inflação de tarefa",
+        "titulo":"Lei de Parkinson",
+        "resumo":"Limite o tempo que leva para concluir uma tarefa ao que as pessoas normalmente esperam que ela leve. Quando existe um grande número de passos até a conclusão de algo, podemos preparar facilitadores que contribuam significativamente para o resultado desejado. Um exemplo é o preenchimento automático ao digitar, que é um recurso para economizar tempo ao preencher informações críticas em formulários. Recursos como esse permitem a conclusão rápida de compras, reservas e outras funções semelhantes, evitando a inflação das tarefas.",
         "leiaMais":"https://medium.com/the-mission/parkinsons-law-why-constraints-are-the-best-thing-you-can-work-with-4fad6e0e91cf",
         "asset":"Lei_De_Parkinson",
         "exemplo":"parkinson",
@@ -65,7 +65,7 @@
     {
         "categoria":"princípio",
         "titulo":"Limiar de Doherty",
-        "resumo":"As melhores formas de se utilizar da lei Limiar de Doherty é tendo maneiras de lidar com atrasos, como por exemplo utilizar animações durante um processo demorado (>400ms). Barras de progressão são ótimas práticas como feedback para o usuário, ajudando a deixar a demora tolerável. Outro ponto importante que deve-se levar em consideração é o desempenho percebido, o qual é uma forma de trazer a sensação de que a execução do software foi mais rápida do que aparenta.",
+        "resumo":"Quando uma pessoa está usando um computador e não precisa ficar esperando por ele, o nível de satisfação com o sistema aumenta consideravelmente, o que aumenta a produtividade e a qualidade do trabalho. O Limiar de Doherty estabelece que o tempo de resposta ideal de um software é de 400 milissegundos. Quando não é possível permanecer nesse limite, designers precisam criar maneiras de lidar com os atrasos. Entre as práticas mais comuns estão o uso de animações e barras de progresso. Procure formas de proporcionar a sensação de que a execução do software foi mais rápida do que realmente é. Isso melhora o desempenho percebido do sistema.",
         "leiaMais":"https://jlelliotton.blogspot.ca/p/the-economic-value-of-rapid-response.html",
         "asset":"Limiar_De_Doherty",
         "exemplo":"dohertyImage0",
@@ -75,7 +75,7 @@
     {
         "categoria":"princípio",
         "titulo":"Navalha de Occam",
-        "resumo":"A Navalha de Occam prevê que a melhor forma de deixar o design efetivo, é deixá-lo da maneira mais simples possível. Cada elemento deve ser analisado minuciosamente e dentre possíveis opções para o elemento, escolher o mais simples, sem comprometer a usabilidade.",
+        "resumo":"De maneira resumida, a Navalha de Occam é um princípio para resolução de problemas segundo o qual devemos sempre privilegiar a solução mais simples quando os resultados são os mesmos. Aplicado ao design, ele prevê que uma interface mais efetiva geralmente é a mais simples possível. Cada elemento deve ser analisado minuciosamente e, dentre as possíveis opções para ele, devemos escolher a mais simples, sem comprometer a usabilidade. Lembre-se de que não deve haver complexidade onde não há necessidade.",
         "leiaMais":"https://medium.com/@jonyablonski/designing-with-occams-razor-3692df2f3c7f",
         "asset":"Navalha_De_Occam",
         "exemplo":"occam",
@@ -84,7 +84,7 @@
     {
         "categoria":"princípio",
         "titulo":"Princípio de Pareto",
-        "resumo":"O princípio de Pareto afirma que, para muitos eventos, cerca de 80% dos efeitos vêm de 20% das causas. - As entradas e saídas geralmente não são distribuídas uniformemente. - Um grande grupo pode conter apenas alguns contribuintes significativos para o resultado desejado. - Concentre a maior parte do esforço nas áreas que trarão os maiores benefícios para a maioria dos usuários. O Princípio de Pareto é utilizado para direcionar um foco específico. Dessa forma, cerca de 80% dos efeitos vêm de 20% das causas.",
+        "resumo":"O princípio de Pareto afirma que cerca de 80 por cento dos efeitos de um processo vêm de 20 por cento das causas. A proporção pode variar um pouco, mas a ideia principal é a de que, dentro de qualquer sistema, apenas algumas variáveis principais afetam os resultados, a maioria dos outros fatores têm pouco ou nenhum impacto. Desta forma, devemos focar nossos esforços e recursos nos aspectos do produto que geram mais valor e que trazem os maiores benefícios à maioria das pessoas que o utilizam. Em interfaces, prefira elementos que realmente importam. Em um menu com botões de ação, por exemplo, reduza a quantidade de botões ao essencial.",
         "leiaMais":"https://shre.ink/cok0",
         "asset":"Principio_De_Pareto",
         "exemplo":"pareto",
@@ -93,7 +93,7 @@
     {
         "categoria":"princípio",
         "titulo":"Lei de Postel",
-        "resumo":"Seja liberal no que você aceita e conservador no que você envia. Seja flexível e tolerante com as várias ações que o usuário possa tomar. Quanto mais planejado o design, mais resiliente será o design. Aceite a entrada variável dos usuários, traduzindo essa entrada para atender às suas necessidades, definindo limites para a entrada e fornecendo feedback claro ao usuário. Para dar ao usuário uma experiência positiva, a interface deve ser empática, flexível e tolerante para cada ação que o usuário tomar.",
+        "resumo":"Seja liberal no que você aceita e conservador no que você envia. Seja flexível e tolerante com as várias ações que a pessoa que usa seu aplicativo possa tomar. Quanto melhor planejado o design, mais resiliente neste sentido ele será. Seu aplicativo deve aceitar inserções e entradas variáveis das pessoas que o utilizam, adaptando-as para atender a suas necessidades. Defina limites para o que as pessoas podem inserir e forneça feedbacks claros. Para que as pessoas tenham uma experiência positiva, a interface deve ser empática, flexível e tolerante para cada ação que elas podem tomar.",
         "leiaMais":"https://markboulton.co.uk/journal/2016-05-17.design-systems-and-postels-law/",
         "asset":"Lei_De_Postel",
         "exemplo":"postel",
@@ -102,7 +102,7 @@
     {
         "categoria":"princípio",
         "titulo":"Lei de Tesler",
-        "resumo":"A Lei de Tesler, também chamada de Lei da Conservação da Complexidade, afirma que em um sistema, toda a complexidade que há tem um limite de redução e devemos tentar alcançar esse limite. Dito isso, toda a complexidade que o usuário lidaria, o sistema deve lidar, sempre tomando cuidado para não ultrapassar o limite e acabar chegando em uma abstração.",
+        "resumo":"A Lei de Tesler, também conhecida como Lei da Conservação da Complexidade, afirma que, em um sistema, toda a complexidade existente tem um limite de redução que devemos tentar alcançar. A pessoa que usa um sistema não precisa conhecer toda a complexidade necessária para que ele funcione. Devemos tentar fazer com que o próprio sistema lide com tal complexidade, retirando essa responsabilidade das pessoas. Mas tome cuidado para não ultrapassar o limite e criar uma abstração simples demais, tirando a sensação de controle da pessoa usuária. O sistema de Face ID da Apple é um bom exemplo de simplificação da complexidade do processo de login.",
         "leiaMais":"https://fs.blog/2020/10/why-life-cant-be-simpler/",
         "asset":"Lei_De_Tesler",
         "exemplo":"tesler",
@@ -111,7 +111,7 @@
     {
         "categoria":"gestalt",
         "titulo":"Lei da Região Comum",
-        "resumo":"As Leis de agrupamento são conjuntos de princípios em psicologia, que foram propostos por psicólogos da Gestalt, onde explicam sobre a tendência humana de buscar e encontrar padrões, esse princípio é conhecido como Prägnanz. Os psicólogos da pesquisa argumentaram que esses princípios existem porque a mente tem uma disposição inata para perceber padrões no estímulo com base em certas regras. Assim, foi organizado esses princípios em cinco categorias: Proximidade, Similaridade, Continuidade, Fechamento e Conectividade.",
+        "resumo":"As Leis de Agrupamento são conjuntos de princípios em psicologia que foram propostos por teóricos da Gestalt. Eles explicam como a mente humana tem a tendência inata de buscar e perceber padrões no estímulo sensorial com base em certas regras. Segundo a Lei da Região Comum, percebemos elementos em grupos se eles estiverem em uma área com um limite claramente definido, o que ajuda a entender as relações que podem existir entre eles. Adicionar uma borda entre elementos relacionados ou utilizar cores de fundo diferentes são práticas comuns que ajudam a criar a sensação de agrupamento.",
         "leiaMais":"https://www.smashingmagazine.com/2014/03/design-principles-visual-perception-and-the-principles-of-gestalt/",
         "asset":"Lei_Da_Regiao_Comum",
         "exemplo":"regiaoComum",
@@ -120,7 +120,7 @@
     {
         "categoria":"gestalt",
         "titulo":"Lei da Proximidade",
-        "resumo":"Objetos que estão próximos ou próximos uns dos outros tendem a ser agrupados. A lei da proximidade descreve como o olho humano percebe as conexões entre os elementos visuais. Elementos que estão próximos uns dos outros são percebidos como relacionados quando comparados com elementos que estão separados uns dos outros.",
+        "resumo":"Objetos que estão próximos uns dos outros tendem a ser agrupados. A lei da proximidade descreve como o olho humano percebe as conexões entre os elementos visuais. Elementos que estão próximos uns dos outros são percebidos como relacionados quando comparados com elementos que estão separados. A proximidade colabora para estabelecer as relações necessárias, e ajudará as pessoas que usam seu produto a organizar a informação de forma mais rápida e eficiente.",
         "leiaMais":"https://www.nngroup.com/articles/gestalt-proximity/",
         "asset":"Lei_De_Proximidade",
         "exemplo":"proximidade",
@@ -128,8 +128,8 @@
     },
     {
         "categoria":"gestalt",
-        "titulo":"Lei de Pragnanz",
-        "resumo":"As pessoas vão perceber e interpretar imagens ambíguas ou complexas como a forma mais simples possível, porque é a interpretação que exige o menor esforço cognitivo de nós. Portanto, a lei da concisão nos diz que as pessoas percebem as coisas complexas como formas simplistas para reconhecer facilmente o ambiente. Isso faz com que os humanos entendam o que veem como um todo, e não como pequenos pedaços ou a soma total das partes.",
+        "titulo":"Lei de Prägnanz",
+        "resumo":"De acordo com o Princípio de Prägnanz, também conhecido como Lei da Concisão, as pessoas perceberão e interpretarão imagens ambíguas ou complexas como a forma mais simples possível, porque esta é a interpretação que envolve o menor esforço cognitivo. Quando estamos diante de formas complexas, tendemos a organizá-las em componentes mais simples ou em um todo mais simples. Isso nos auxilia, por exemplo, a reconhecer facilmente o ambiente. É uma característica dos seres humanos entenderem o que veem como um todo, e não como pequenos pedaços ou como a soma total das partes.",
         "leiaMais":"https://www.interaction-design.org/literature/article/the-laws-of-figure-ground-praegnanz-closure-and-common-fate-gestalt-principles-3",
         "asset":"Lei_De_Pragnanz",
         "exemplo":"pregnancia",
@@ -138,7 +138,7 @@
     {
         "categoria":"gestalt",
         "titulo":"Lei da Semelhança",
-        "resumo":"O olho humano tende a perceber elementos semelhantes em um design como uma imagem completa, forma ou grupo, mesmo que esses elementos estejam separados. - Elementos que são visualmente semelhantes serão percebidos como relacionados. - Cor, forma e tamanho, orientação e movimento podem sinalizar que os elementos pertencem ao mesmo grupo e provavelmente compartilham um significado ou funcionalidade comum. - Certifique-se de que os links e os sistemas de navegação sejam visualmente diferenciados dos elementos de texto normais.",
+        "resumo":"O olho humano tende a perceber elementos semelhantes em um design como uma imagem completa, forma ou grupo, mesmo que esses elementos estejam separados. Assim, elementos que são visualmente semelhantes serão percebidos como relacionados. Cor, forma e tamanho, orientação e movimento podem sinalizar que os elementos pertencem ao mesmo grupo e provavelmente compartilham um significado ou funcionalidade comum. Certifique-se de que os links e os sistemas de navegação sejam visualmente diferenciados dos elementos de texto normais.",
         "leiaMais":"https://www.nngroup.com/articles/gestalt-similarity/",
         "asset":"Lei_De_Semelhanca",
         "exemplo":"similaridade",
@@ -147,7 +147,7 @@
     {
         "categoria":"gestalt",
         "titulo":"Lei da Conectividade Uniforme",
-        "resumo":"Elementos visualmente conectados são percebidos como mais relacionados do que elementos sem conexão. - Agrupe funções de natureza semelhante para que sejam visualmente conectadas por meio de cores, linhas, molduras ou outras formas. - Alternativamente, você pode usar uma referência de conexão tangível (linha, seta, etc) de um elemento para o próximo para também criar uma conexão visual. - Use conectividade uniforme para mostrar o contexto ou enfatizar a relação entre itens semelhantes.",
+        "resumo":"Elementos visualmente conectados são percebidos como mais relacionados do que elementos sem conexão. Agrupe funções de natureza semelhante para que sejam visualmente conectadas por meio de cores, linhas, molduras ou outras formas. Alternativamente, você pode usar uma referência de conexão tangível, como linhas ou setas, para também criar uma conexão visual. Use a Conectividade Uniforme para deixar o contexto o mais claro possível ou enfatizar a relação entre itens semelhantes.",
         "leiaMais":"http://www.andyrutledge.com/gestalt-principles-3.html",
         "asset":"Lei_Da_Conectividade_Uniforme",
         "exemplo":"conectividadeUniforme",
@@ -156,7 +156,7 @@
     {
         "categoria":"Viés Cognitivo",
         "titulo":"Regra do Pico Final",
-        "resumo":"As pessoas julgam uma experiência em grande parte com base em como se sentiram no auge e no final, em vez da soma total ou média de cada momento da experiência. Peak-End Rule é uma regra psicológica em que uma experiência é lembrada e avaliada com base no ponto máximo (mais intenso) da experiência e/ou no final da experiência.",
+        "resumo":"As pessoas julgam uma experiência em grande parte com base em como se sentiram no auge e no final dela, em vez da soma total ou média de cada momento. A Regra do Pico Final é uma regra psicológica que sugere que uma experiência geralmente é lembrada e avaliada com base em seu ponto máximo ou mais intenso, assim como em seu ponto final. Lembre que as pessoas lembram de experiências ruins mais facilmente que de experiências positivas. Identifique os momentos em que seu produto é mais útil, valioso ou divertido e crie um design que encante a pessoa que está usando seu produto.",
         "leiaMais":"https://uxdesign.cc/peak-end-rule-54eedd375c4d",
         "asset":"Regra_De_Pico_Final",
         "exemplo":"picofinal",
@@ -165,7 +165,7 @@
     {
         "categoria":"Viés Cognitivo",
         "titulo":"Efeito de Posição Serial",
-        "resumo":"O efeito de posição serial, descreve como a posição de um item em uma sequência afeta a precisão da recordação. Os dois conceitos envolvidos, o efeito de primazia e o efeito de recência, explicam como os itens apresentados no início e no final de uma sequência são lembrados com maior precisão do que os itens no meio de uma lista. A manipulação do efeito de posição serial para criar melhores experiências de usuário é refletida em muitos designs populares de empresas de sucesso.",
+        "resumo":"O Efeito de Posição Serial descreve como a posição de um item em uma sequência afeta o quão precisa é a nossa memória dele. Há dois outros efeitos envolvidos neste caso: o Efeito de Primazia e o Efeito de Recência, que explicam como os itens apresentados no início e no final de uma sequência são lembrados com maior Precisão do que os itens no meio de uma lista. A utilização do Efeito de Posição Serial para criar melhores experiências de usuário é refletida em muitos designs populares de empresas de sucesso.",
         "leiaMais":"https://www.interaction-design.org/literature/article/serial-position-effect-how-to-create-better-user-interfaces",
         "asset":"Efeito_De_Posicao_Serial",
         "exemplo":"posiçãoSerial",
@@ -173,8 +173,8 @@
     },
     {
         "categoria":"Viés Cognitivo",
-        "titulo":"Efeito Von Restorff",
-        "resumo":"O efeito Von Restorff, também conhecido como Efeito de Isolamento, prevê que, quando vários objetos semelhantes estão presentes, aquele que difere do resto tem maior probabilidade de ser lembrado. A teoria foi definida pelo psiquiatra e pediatra alemão Hedwig von Restorff, que, em seu estudo de 1933, descobriu que, quando os participantes recebiam uma lista de itens categoricamente semelhantes com um item distinto e isolado na lista, a memória para o item foi melhorado.",
+        "titulo":"Efeito de von Restorff",
+        "resumo":"O Efeito de von Restorff, também conhecido como Efeito de Isolamento, prevê que, quando vários objetos semelhantes estão presentes, aquele que difere do resto tem maior probabilidade de ser lembrado. A teoria foi definida pela psiquiatra e pediatra alemã Hedwig von Restorff. Em um estudo de 1933, von Restorff descobriu que, quando as pessoas recebiam uma lista de itens categoricamente semelhantes contendo um item distinto e isolado, a memória para este item específico foi melhorada.",
         "leiaMais":"https://blog.marvelapp.com/psychology-principles-every-uiux-designer-needs-know/",
         "asset":"Efeito_Von_Restorff",
         "exemplo":"vonRestorff",
@@ -183,7 +183,7 @@
     {
         "categoria":"Viés Cognitivo",
         "titulo":"Efeito Zeigarnik",
-        "resumo":"O Efeito Zeigarnik explica que tarefas incompletas são mais fáceis de lembrar do que as bem-sucedidas. Então ter recursos visuais que representem a incompletude da tarefa é fundamental para ajudar a enfatizar a tensão específica da tarefa e encorajar o usuário a se lembrar da tarefa. Barras de progresso, círculos, marcas de seleção ou indicadores de etapas são excelentes maneiras de indicar quando uma tarefa foi concluída. Além disso, você sabe, quanto mais sentimentos positivos seu usuário associar ao seu produto, maior a probabilidade de ele voltar.",
+        "resumo":"O Efeito Zeigarnik explica que tarefas incompletas são mais fáceis de lembrar do que as bem-sucedidas. Assim, preparar recursos visuais que representem a incompletude da tarefa é fundamental para enfatizar a tensão específica que encoraja a pessoa usuária a se lembrar dela. Barras de progresso, círculos, marcas de seleção ou indicadores de etapas são excelentes maneiras de indicar quando uma tarefa foi concluída. Não se esqueça de que quanto mais sentimentos positivos a pessoa que usa o seu produto associar a ele, maior a probabilidade de ela voltar.",
         "leiaMais":"https://uxdesign.cc/endowed-progress-effect-give-your-users-a-head-start-97d52d8b0396",
         "asset":"Efeito_Zeigarnik",
         "exemplo":"zeigarnik",

--- a/UXperience/ViewModel/Model/Base.lproj/laws.json
+++ b/UXperience/ViewModel/Model/Base.lproj/laws.json
@@ -173,8 +173,8 @@
     },
     {
         "categoria":"Viés Cognitivo",
-        "titulo":"Efeito de von Restorff",
-        "resumo":"O Efeito de von Restorff, também conhecido como Efeito de Isolamento, prevê que, quando vários objetos semelhantes estão presentes, aquele que difere do resto tem maior probabilidade de ser lembrado. A teoria foi definida pela psiquiatra e pediatra alemã Hedwig von Restorff. Em um estudo de 1933, von Restorff descobriu que, quando as pessoas recebiam uma lista de itens categoricamente semelhantes contendo um item distinto e isolado, a memória para este item específico foi melhorada.",
+        "titulo":"Efeito von Restorff",
+        "resumo":"O Efeito von Restorff, também conhecido como Efeito de Isolamento, prevê que, quando vários objetos semelhantes estão presentes, aquele que difere do resto tem maior probabilidade de ser lembrado. A teoria foi definida pela psiquiatra e pediatra alemã Hedwig von Restorff. Em um estudo de 1933, von Restorff descobriu que, quando as pessoas recebiam uma lista de itens categoricamente semelhantes contendo um item distinto e isolado, a memória para este item específico foi melhorada.",
         "leiaMais":"https://blog.marvelapp.com/psychology-principles-every-uiux-designer-needs-know/",
         "asset":"Efeito_Von_Restorff",
         "exemplo":"vonRestorff",

--- a/UXperience/ViewModel/Model/pt-BR.lproj/laws.json
+++ b/UXperience/ViewModel/Model/pt-BR.lproj/laws.json
@@ -173,8 +173,8 @@
     },
     {
         "categoria":"Viés Cognitivo",
-        "titulo":"Efeito de von Restorff",
-        "resumo":"O Efeito de von Restorff, também conhecido como Efeito de Isolamento, prevê que, quando vários objetos semelhantes estão presentes, aquele que difere do resto tem maior probabilidade de ser lembrado. A teoria foi definida pela psiquiatra e pediatra alemã Hedwig von Restorff. Em um estudo de 1933, von Restorff descobriu que, quando as pessoas recebiam uma lista de itens categoricamente semelhantes contendo um item distinto e isolado, a memória para este item específico foi melhorada.",
+        "titulo":"Efeito von Restorff",
+        "resumo":"O Efeito von Restorff, também conhecido como Efeito de Isolamento, prevê que, quando vários objetos semelhantes estão presentes, aquele que difere do resto tem maior probabilidade de ser lembrado. A teoria foi definida pela psiquiatra e pediatra alemã Hedwig von Restorff. Em um estudo de 1933, von Restorff descobriu que, quando as pessoas recebiam uma lista de itens categoricamente semelhantes contendo um item distinto e isolado, a memória para este item específico foi melhorada.",
         "leiaMais":"https://blog.marvelapp.com/psychology-principles-every-uiux-designer-needs-know/",
         "asset":"Efeito_Von_Restorff",
         "exemplo":"vonRestorff",

--- a/UXperience/ViewModel/Model/pt-BR.lproj/laws.json
+++ b/UXperience/ViewModel/Model/pt-BR.lproj/laws.json
@@ -2,7 +2,7 @@
     {
         "categoria":"heurística",
         "titulo":"Efeito de Usabilidade Estética",
-        "resumo":"Um design agradável cria uma resposta positiva no cérebro das pessoas e as leva a acreditar que o design realmente funciona melhor. As pessoas são mais tolerantes com pequenos problemas de usabilidade quando o design de um produto ou serviço tem uma estética agradável. O design visualmente agradável pode esconder problemas de usabilidade e evitar que problemas sejam descobertos durante o teste de usabilidade.  A usabilidade e a estética são os dois fatores mais importantes na avaliação da experiência geral do usuário para um aplicativo. Elas são julgadas pelas expectativas de reutilização de um usuário e, em seguida, seu julgamento final pós-uso ou experiente.",
+        "resumo":"Um design agradável cria uma resposta positiva no cérebro das pessoas e as leva a crer que o produto ou serviço funciona melhor. As pessoas são mais tolerantes com pequenos problemas de usabilidade quando o design tem uma estética agradável. Um design visualmente agradável pode esconder problemas e até evitar que eles sejam descobertos durante testes. Usabilidade e estética são os dois fatores mais importantes na avaliação da experiência geral da pessoa que usa um aplicativo. Elas são avaliadas tanto pelas expectativas de reutilização do app quanto pelo julgamento final sobre ele, seja este um julgamento experiente ou apenas uma opinião pós-uso.",
         "leiaMais":"https://www.nngroup.com/articles/aesthetic-usability-effect/",
         "asset":"Efeito_de_Usabilidade_Estetica",
         "exemplo":"usabilidadeEstética",
@@ -10,8 +10,8 @@
     },
     {
         "categoria":"heurística",
-        "titulo":"Lei de Fitt's",
-        "resumo":"Os alvos de toque devem ser grandes o suficiente para que os usuários os selecionem com precisão. Eles devem ter amplo espaçamento entre eles, assim como devem ser colocados em áreas de fácil acesso. À medida que você cria novos designs de interface do usuário, pense em otimizar a distância e o tamanho ​​criando alvos grandes, bem espaçados e posicionando-os de modo que fiquem próximos da localização anterior mais provável para o usuário.",
+        "titulo":"Lei de Fitt",
+        "resumo":"Os alvos de toque em uma interface devem ser grandes o suficiente para que qualquer pessoa consiga selecioná-los com precisão. Devem ser colocados em áreas de fácil acesso e deve haver um amplo espaçamento entre eles. À medida em que você cria novos designs de interface, pense em otimizar a distância e o tamanho dos elementos ​​criando alvos grandes, bem espaçados e posicionados de modo que fiquem próximos da localização do dedo ou cursor da pessoa que está usando seu app. Boas práticas em interfaces incluem evitar aglomerações de alvos, usar alvos grandes, escolher ícones seguidos de legenda e criar alvos bastante amplos sempre que possível.",
         "leiaMais":"https://www.nngroup.com/articles/fitts-law/",
         "asset":"Lei_De_Fitts",
         "exemplo":"fitts",
@@ -19,8 +19,8 @@
     },
     {
         "categoria":"heurística",
-        "titulo":"Efeito Gradiente de Objectivos",
-        "resumo":"A tendência de se aproximar de um objetivo aumenta com a proximidade do objetivo.Quanto mais próximos os usuários estiverem de concluir uma tarefa, mais rápido eles trabalharão para alcançá-la. Fornecer a sensação de progresso em direção a uma meta ajudará a garantir que os usuários tenham mais motivação para concluir essa tarefa. Forneça uma indicação clara do progresso para motivar os usuários a concluir as tarefas.",
+        "titulo":"Efeito Gradiente de Objetivos",
+        "resumo":"O entusiasmo para atingirmos um objetivo aumenta na medida em que nos aproximamos dele. Quanto mais próximas as pessoas que utilizam seu produto estiverem de concluir uma tarefa, mais rápido elas se esforçarão para terminá-la. Fornecer a sensação de progresso em direção a uma meta ajudará a garantir que as pessoas tenham mais motivação para alcançá-la. Forneça indicações claras do progresso de tarefas ou mostre cada passo do processo enquanto a pessoa usuária espera por algo.",
         "leiaMais":"https://medium.com/choice-hacking/how-uber-uses-psychology-to-perfect-their-customer-experience-d6c440285029",
         "asset":"Efeito_De_Nivel_De_Gradiente",
         "exemplo":"gradiente",
@@ -28,12 +28,12 @@
     },
     {
         "categoria":"heurística",
-        "titulo":"Lei de Hick`s",
-        "resumo":"O tempo que leva para tomar uma decisão aumenta com o número e a complexidade das escolhas. Diminua as opções de escolha quando o tempo de resposta for curto, quebre uma tarefa grande em várias pequenas, evite sobrecarregar os usuários destacando as opções recomendadas. Tenha cuidado para não simplificar demais e chegar ao ponto do usuário não entender. Às vezes, não há como evitar a complexidade, quando temos uma grande quantidade de informações necessárias. O objetivo da Lei de Hick é tentar simplificar o processo de tomada de decisão, não eliminá -lo totalmente.",
+        "titulo":"Lei de Hick",
+        "resumo":"O tempo que leva para tomar uma decisão aumenta com o número e a complexidade das escolhas. Quando o tempo para resposta for curto, diminua as opções de escolha ou quebre uma tarefa grande em várias pequenas. Você pode também destacar as opções recomendadas para não sobrecarregar as pessoas que usam seu produto. Mas tenha cuidado para não simplificar demais até chegar ao ponto de deixar a interface difícil de entender. Às vezes, quando temos uma grande quantidade de informações necessárias, não há como evitar a complexidade. O objetivo da Lei de Hick é tentar simplificar o processo de tomada de decisão, não eliminá-lo totalmente.",
         "leiaMais":"https://medium.com/choice-hacking/choice-overload-why-simplicity-is-the-key-to-winning-customers-2f8e239eaba6",
         "asset":"Lei_De_Hick",
         "exemplo":"hicklaw",
-        "descrição_exemplo":"Exemplo de pergunta com respostas de múltipla escolha. A pergunta é “Como você está se sentindo hoje?”. Há apenas três respostas possíveis: Ótimo, Bem e Ruim."
+        "descrição_exemplo":"Exemplo de pergunta com respostas de múltipla escolha. A pergunta é “Como você está se sentindo hoje?”. Há  apenas três respostas possíveis: Ótimo, Bem e Ruim."
     },
     {
         "categoria":"heurística",
@@ -46,8 +46,8 @@
     },
     {
         "categoria":"heurística",
-        "titulo":"Lei de Miller's",
-        "resumo":"Qualquer elemento que não esteja ajudando o usuário a atingir seu objetivo está trabalhando contra ele. Lembre-se de que a capacidade de memória de curto prazo varia de pessoa para pessoa, com base em seu conhecimento prévio e contexto situacional. Organize o conteúdo em partes menores para ajudar os usuários a processar, entender e memorizar facilmente. Embora a carga cognitiva não seja totalmente evitável, os designers devem se esforçar para gerenciar e acomodar esses limites.",
+        "titulo":"Lei de Miller",
+        "resumo":"Qualquer elemento que não esteja ajudando a pessoa usuária a atingir seu objetivo está trabalhando contra ela. Lembre-se de que a capacidade de memória de curto prazo varia de pessoa para pessoa, com base em seu contexto e conhecimento prévio. Organize o conteúdo em partes menores para ajudar as pessoas que usam seu produto a processar, entender e memorizar informações facilmente. Embora a carga cognitiva nunca seja completamente, designers devem se esforçar para gerenciar e acomodar esses limites.",
         "leiaMais":"https://blog.prototypr.io/design-principles-for-reducing-cognitive-load-84e82ca61abd",
         "asset":"Lei_De_Miller",
         "exemplo":"miller",
@@ -55,8 +55,8 @@
     },
     {
         "categoria":"heurística",
-        "titulo":"Lei de Parkinson`s",
-        "resumo":"Limite o tempo que leva para concluir uma tarefa ao que os usuários esperam que ela leve. Um grande grupo pode conter apenas alguns contribuintes significativos para o resultado desejado. Recursos como preenchimento automático para economizar tempo do usuário ao fornecer informações críticas nos formulários. Isso permite a conclusão rápida de compras, reservas e outras funções semelhantes, evitando a inflação de tarefa",
+        "titulo":"Lei de Parkinson",
+        "resumo":"Limite o tempo que leva para concluir uma tarefa ao que as pessoas normalmente esperam que ela leve. Quando existe um grande número de passos até a conclusão de algo, podemos preparar facilitadores que contribuam significativamente para o resultado desejado. Um exemplo é o preenchimento automático ao digitar, que é um recurso para economizar tempo ao preencher informações críticas em formulários. Recursos como esse permitem a conclusão rápida de compras, reservas e outras funções semelhantes, evitando a inflação das tarefas.",
         "leiaMais":"https://medium.com/the-mission/parkinsons-law-why-constraints-are-the-best-thing-you-can-work-with-4fad6e0e91cf",
         "asset":"Lei_De_Parkinson",
         "exemplo":"parkinson",
@@ -65,7 +65,7 @@
     {
         "categoria":"princípio",
         "titulo":"Limiar de Doherty",
-        "resumo":"As melhores formas de se utilizar da lei Limiar de Doherty é tendo maneiras de lidar com atrasos, como por exemplo utilizar animações durante um processo demorado (>400ms). Barras de progressão são ótimas práticas como feedback para o usuário, ajudando a deixar a demora tolerável. Outro ponto importante que deve-se levar em consideração é o desempenho percebido, o qual é uma forma de trazer a sensação de que a execução do software foi mais rápida do que aparenta.",
+        "resumo":"Quando uma pessoa está usando um computador e não precisa ficar esperando por ele, o nível de satisfação com o sistema aumenta consideravelmente, o que aumenta a produtividade e a qualidade do trabalho. O Limiar de Doherty estabelece que o tempo de resposta ideal de um software é de 400 milissegundos. Quando não é possível permanecer nesse limite, designers precisam criar maneiras de lidar com os atrasos. Entre as práticas mais comuns estão o uso de animações e barras de progresso. Procure formas de proporcionar a sensação de que a execução do software foi mais rápida do que realmente é. Isso melhora o desempenho percebido do sistema.",
         "leiaMais":"https://jlelliotton.blogspot.ca/p/the-economic-value-of-rapid-response.html",
         "asset":"Limiar_De_Doherty",
         "exemplo":"dohertyImage0",
@@ -75,7 +75,7 @@
     {
         "categoria":"princípio",
         "titulo":"Navalha de Occam",
-        "resumo":"A Navalha de Occam prevê que a melhor forma de deixar o design efetivo, é deixá-lo da maneira mais simples possível. Cada elemento deve ser analisado minuciosamente e dentre possíveis opções para o elemento, escolher o mais simples, sem comprometer a usabilidade.",
+        "resumo":"De maneira resumida, a Navalha de Occam é um princípio para resolução de problemas segundo o qual devemos sempre privilegiar a solução mais simples quando os resultados são os mesmos. Aplicado ao design, ele prevê que uma interface mais efetiva geralmente é a mais simples possível. Cada elemento deve ser analisado minuciosamente e, dentre as possíveis opções para ele, devemos escolher a mais simples, sem comprometer a usabilidade. Lembre-se de que não deve haver complexidade onde não há necessidade.",
         "leiaMais":"https://medium.com/@jonyablonski/designing-with-occams-razor-3692df2f3c7f",
         "asset":"Navalha_De_Occam",
         "exemplo":"occam",
@@ -84,7 +84,7 @@
     {
         "categoria":"princípio",
         "titulo":"Princípio de Pareto",
-        "resumo":"O princípio de Pareto afirma que, para muitos eventos, cerca de 80% dos efeitos vêm de 20% das causas. - As entradas e saídas geralmente não são distribuídas uniformemente. - Um grande grupo pode conter apenas alguns contribuintes significativos para o resultado desejado. - Concentre a maior parte do esforço nas áreas que trarão os maiores benefícios para a maioria dos usuários. O Princípio de Pareto é utilizado para direcionar um foco específico. Dessa forma, cerca de 80% dos efeitos vêm de 20% das causas.",
+        "resumo":"O princípio de Pareto afirma que cerca de 80 por cento dos efeitos de um processo vêm de 20 por cento das causas. A proporção pode variar um pouco, mas a ideia principal é a de que, dentro de qualquer sistema, apenas algumas variáveis principais afetam os resultados, a maioria dos outros fatores têm pouco ou nenhum impacto. Desta forma, devemos focar nossos esforços e recursos nos aspectos do produto que geram mais valor e que trazem os maiores benefícios à maioria das pessoas que o utilizam. Em interfaces, prefira elementos que realmente importam. Em um menu com botões de ação, por exemplo, reduza a quantidade de botões ao essencial.",
         "leiaMais":"https://shre.ink/cok0",
         "asset":"Principio_De_Pareto",
         "exemplo":"pareto",
@@ -93,7 +93,7 @@
     {
         "categoria":"princípio",
         "titulo":"Lei de Postel",
-        "resumo":"Seja liberal no que você aceita e conservador no que você envia. Seja flexível e tolerante com as várias ações que o usuário possa tomar. Quanto mais planejado o design, mais resiliente será o design. Aceite a entrada variável dos usuários, traduzindo essa entrada para atender às suas necessidades, definindo limites para a entrada e fornecendo feedback claro ao usuário. Para dar ao usuário uma experiência positiva, a interface deve ser empática, flexível e tolerante para cada ação que o usuário tomar.",
+        "resumo":"Seja liberal no que você aceita e conservador no que você envia. Seja flexível e tolerante com as várias ações que a pessoa que usa seu aplicativo possa tomar. Quanto melhor planejado o design, mais resiliente neste sentido ele será. Seu aplicativo deve aceitar inserções e entradas variáveis das pessoas que o utilizam, adaptando-as para atender a suas necessidades. Defina limites para o que as pessoas podem inserir e forneça feedbacks claros. Para que as pessoas tenham uma experiência positiva, a interface deve ser empática, flexível e tolerante para cada ação que elas podem tomar.",
         "leiaMais":"https://markboulton.co.uk/journal/2016-05-17.design-systems-and-postels-law/",
         "asset":"Lei_De_Postel",
         "exemplo":"postel",
@@ -102,7 +102,7 @@
     {
         "categoria":"princípio",
         "titulo":"Lei de Tesler",
-        "resumo":"A Lei de Tesler, também chamada de Lei da Conservação da Complexidade, afirma que em um sistema, toda a complexidade que há tem um limite de redução e devemos tentar alcançar esse limite. Dito isso, toda a complexidade que o usuário lidaria, o sistema deve lidar, sempre tomando cuidado para não ultrapassar o limite e acabar chegando em uma abstração.",
+        "resumo":"A Lei de Tesler, também conhecida como Lei da Conservação da Complexidade, afirma que, em um sistema, toda a complexidade existente tem um limite de redução que devemos tentar alcançar. A pessoa que usa um sistema não precisa conhecer toda a complexidade necessária para que ele funcione. Devemos tentar fazer com que o próprio sistema lide com tal complexidade, retirando essa responsabilidade das pessoas. Mas tome cuidado para não ultrapassar o limite e criar uma abstração simples demais, tirando a sensação de controle da pessoa usuária. O sistema de Face ID da Apple é um bom exemplo de simplificação da complexidade do processo de login.",
         "leiaMais":"https://fs.blog/2020/10/why-life-cant-be-simpler/",
         "asset":"Lei_De_Tesler",
         "exemplo":"tesler",
@@ -111,7 +111,7 @@
     {
         "categoria":"gestalt",
         "titulo":"Lei da Região Comum",
-        "resumo":"As Leis de agrupamento são conjuntos de princípios em psicologia, que foram propostos por psicólogos da Gestalt, onde explicam sobre a tendência humana de buscar e encontrar padrões, esse princípio é conhecido como Prägnanz. Os psicólogos da pesquisa argumentaram que esses princípios existem porque a mente tem uma disposição inata para perceber padrões no estímulo com base em certas regras. Assim, foi organizado esses princípios em cinco categorias: Proximidade, Similaridade, Continuidade, Fechamento e Conectividade.",
+        "resumo":"As Leis de Agrupamento são conjuntos de princípios em psicologia que foram propostos por teóricos da Gestalt. Eles explicam como a mente humana tem a tendência inata de buscar e perceber padrões no estímulo sensorial com base em certas regras. Segundo a Lei da Região Comum, percebemos elementos em grupos se eles estiverem em uma área com um limite claramente definido, o que ajuda a entender as relações que podem existir entre eles. Adicionar uma borda entre elementos relacionados ou utilizar cores de fundo diferentes são práticas comuns que ajudam a criar a sensação de agrupamento.",
         "leiaMais":"https://www.smashingmagazine.com/2014/03/design-principles-visual-perception-and-the-principles-of-gestalt/",
         "asset":"Lei_Da_Regiao_Comum",
         "exemplo":"regiaoComum",
@@ -120,7 +120,7 @@
     {
         "categoria":"gestalt",
         "titulo":"Lei da Proximidade",
-        "resumo":"Objetos que estão próximos ou próximos uns dos outros tendem a ser agrupados. A lei da proximidade descreve como o olho humano percebe as conexões entre os elementos visuais. Elementos que estão próximos uns dos outros são percebidos como relacionados quando comparados com elementos que estão separados uns dos outros.",
+        "resumo":"Objetos que estão próximos uns dos outros tendem a ser agrupados. A lei da proximidade descreve como o olho humano percebe as conexões entre os elementos visuais. Elementos que estão próximos uns dos outros são percebidos como relacionados quando comparados com elementos que estão separados. A proximidade colabora para estabelecer as relações necessárias, e ajudará as pessoas que usam seu produto a organizar a informação de forma mais rápida e eficiente.",
         "leiaMais":"https://www.nngroup.com/articles/gestalt-proximity/",
         "asset":"Lei_De_Proximidade",
         "exemplo":"proximidade",
@@ -128,8 +128,8 @@
     },
     {
         "categoria":"gestalt",
-        "titulo":"Lei de Pragnanz",
-        "resumo":"As pessoas vão perceber e interpretar imagens ambíguas ou complexas como a forma mais simples possível, porque é a interpretação que exige o menor esforço cognitivo de nós. Portanto, a lei da concisão nos diz que as pessoas percebem as coisas complexas como formas simplistas para reconhecer facilmente o ambiente. Isso faz com que os humanos entendam o que veem como um todo, e não como pequenos pedaços ou a soma total das partes.",
+        "titulo":"Lei de Prägnanz",
+        "resumo":"De acordo com o Princípio de Prägnanz, também conhecido como Lei da Concisão, as pessoas perceberão e interpretarão imagens ambíguas ou complexas como a forma mais simples possível, porque esta é a interpretação que envolve o menor esforço cognitivo. Quando estamos diante de formas complexas, tendemos a organizá-las em componentes mais simples ou em um todo mais simples. Isso nos auxilia, por exemplo, a reconhecer facilmente o ambiente. É uma característica dos seres humanos entenderem o que veem como um todo, e não como pequenos pedaços ou como a soma total das partes.",
         "leiaMais":"https://www.interaction-design.org/literature/article/the-laws-of-figure-ground-praegnanz-closure-and-common-fate-gestalt-principles-3",
         "asset":"Lei_De_Pragnanz",
         "exemplo":"pregnancia",
@@ -138,7 +138,7 @@
     {
         "categoria":"gestalt",
         "titulo":"Lei da Semelhança",
-        "resumo":"O olho humano tende a perceber elementos semelhantes em um design como uma imagem completa, forma ou grupo, mesmo que esses elementos estejam separados. - Elementos que são visualmente semelhantes serão percebidos como relacionados. - Cor, forma e tamanho, orientação e movimento podem sinalizar que os elementos pertencem ao mesmo grupo e provavelmente compartilham um significado ou funcionalidade comum. - Certifique-se de que os links e os sistemas de navegação sejam visualmente diferenciados dos elementos de texto normais.",
+        "resumo":"O olho humano tende a perceber elementos semelhantes em um design como uma imagem completa, forma ou grupo, mesmo que esses elementos estejam separados. Assim, elementos que são visualmente semelhantes serão percebidos como relacionados. Cor, forma e tamanho, orientação e movimento podem sinalizar que os elementos pertencem ao mesmo grupo e provavelmente compartilham um significado ou funcionalidade comum. Certifique-se de que os links e os sistemas de navegação sejam visualmente diferenciados dos elementos de texto normais.",
         "leiaMais":"https://www.nngroup.com/articles/gestalt-similarity/",
         "asset":"Lei_De_Semelhanca",
         "exemplo":"similaridade",
@@ -147,7 +147,7 @@
     {
         "categoria":"gestalt",
         "titulo":"Lei da Conectividade Uniforme",
-        "resumo":"Elementos visualmente conectados são percebidos como mais relacionados do que elementos sem conexão. - Agrupe funções de natureza semelhante para que sejam visualmente conectadas por meio de cores, linhas, molduras ou outras formas. - Alternativamente, você pode usar uma referência de conexão tangível (linha, seta, etc) de um elemento para o próximo para também criar uma conexão visual. - Use conectividade uniforme para mostrar o contexto ou enfatizar a relação entre itens semelhantes.",
+        "resumo":"Elementos visualmente conectados são percebidos como mais relacionados do que elementos sem conexão. Agrupe funções de natureza semelhante para que sejam visualmente conectadas por meio de cores, linhas, molduras ou outras formas. Alternativamente, você pode usar uma referência de conexão tangível, como linhas ou setas, para também criar uma conexão visual. Use a Conectividade Uniforme para deixar o contexto o mais claro possível ou enfatizar a relação entre itens semelhantes.",
         "leiaMais":"http://www.andyrutledge.com/gestalt-principles-3.html",
         "asset":"Lei_Da_Conectividade_Uniforme",
         "exemplo":"conectividadeUniforme",
@@ -156,7 +156,7 @@
     {
         "categoria":"Viés Cognitivo",
         "titulo":"Regra do Pico Final",
-        "resumo":"As pessoas julgam uma experiência em grande parte com base em como se sentiram no auge e no final, em vez da soma total ou média de cada momento da experiência. Peak-End Rule é uma regra psicológica em que uma experiência é lembrada e avaliada com base no ponto máximo (mais intenso) da experiência e/ou no final da experiência.",
+        "resumo":"As pessoas julgam uma experiência em grande parte com base em como se sentiram no auge e no final dela, em vez da soma total ou média de cada momento. A Regra do Pico Final é uma regra psicológica que sugere que uma experiência geralmente é lembrada e avaliada com base em seu ponto máximo ou mais intenso, assim como em seu ponto final. Lembre que as pessoas lembram de experiências ruins mais facilmente que de experiências positivas. Identifique os momentos em que seu produto é mais útil, valioso ou divertido e crie um design que encante a pessoa que está usando seu produto.",
         "leiaMais":"https://uxdesign.cc/peak-end-rule-54eedd375c4d",
         "asset":"Regra_De_Pico_Final",
         "exemplo":"picofinal",
@@ -165,7 +165,7 @@
     {
         "categoria":"Viés Cognitivo",
         "titulo":"Efeito de Posição Serial",
-        "resumo":"O efeito de posição serial, descreve como a posição de um item em uma sequência afeta a precisão da recordação. Os dois conceitos envolvidos, o efeito de primazia e o efeito de recência, explicam como os itens apresentados no início e no final de uma sequência são lembrados com maior precisão do que os itens no meio de uma lista. A manipulação do efeito de posição serial para criar melhores experiências de usuário é refletida em muitos designs populares de empresas de sucesso.",
+        "resumo":"O Efeito de Posição Serial descreve como a posição de um item em uma sequência afeta o quão precisa é a nossa memória dele. Há dois outros efeitos envolvidos neste caso: o Efeito de Primazia e o Efeito de Recência, que explicam como os itens apresentados no início e no final de uma sequência são lembrados com maior Precisão do que os itens no meio de uma lista. A utilização do Efeito de Posição Serial para criar melhores experiências de usuário é refletida em muitos designs populares de empresas de sucesso.",
         "leiaMais":"https://www.interaction-design.org/literature/article/serial-position-effect-how-to-create-better-user-interfaces",
         "asset":"Efeito_De_Posicao_Serial",
         "exemplo":"posiçãoSerial",
@@ -173,8 +173,8 @@
     },
     {
         "categoria":"Viés Cognitivo",
-        "titulo":"Efeito Von Restorff",
-        "resumo":"O efeito Von Restorff, também conhecido como Efeito de Isolamento, prevê que, quando vários objetos semelhantes estão presentes, aquele que difere do resto tem maior probabilidade de ser lembrado. A teoria foi definida pelo psiquiatra e pediatra alemão Hedwig von Restorff, que, em seu estudo de 1933, descobriu que, quando os participantes recebiam uma lista de itens categoricamente semelhantes com um item distinto e isolado na lista, a memória para o item foi melhorado.",
+        "titulo":"Efeito de von Restorff",
+        "resumo":"O Efeito de von Restorff, também conhecido como Efeito de Isolamento, prevê que, quando vários objetos semelhantes estão presentes, aquele que difere do resto tem maior probabilidade de ser lembrado. A teoria foi definida pela psiquiatra e pediatra alemã Hedwig von Restorff. Em um estudo de 1933, von Restorff descobriu que, quando as pessoas recebiam uma lista de itens categoricamente semelhantes contendo um item distinto e isolado, a memória para este item específico foi melhorada.",
         "leiaMais":"https://blog.marvelapp.com/psychology-principles-every-uiux-designer-needs-know/",
         "asset":"Efeito_Von_Restorff",
         "exemplo":"vonRestorff",
@@ -183,7 +183,7 @@
     {
         "categoria":"Viés Cognitivo",
         "titulo":"Efeito Zeigarnik",
-        "resumo":"O Efeito Zeigarnik explica que tarefas incompletas são mais fáceis de lembrar do que as bem-sucedidas. Então ter recursos visuais que representem a incompletude da tarefa é fundamental para ajudar a enfatizar a tensão específica da tarefa e encorajar o usuário a se lembrar da tarefa. Barras de progresso, círculos, marcas de seleção ou indicadores de etapas são excelentes maneiras de indicar quando uma tarefa foi concluída. Além disso, você sabe, quanto mais sentimentos positivos seu usuário associar ao seu produto, maior a probabilidade de ele voltar.",
+        "resumo":"O Efeito Zeigarnik explica que tarefas incompletas são mais fáceis de lembrar do que as bem-sucedidas. Assim, preparar recursos visuais que representem a incompletude da tarefa é fundamental para enfatizar a tensão específica que encoraja a pessoa usuária a se lembrar dela. Barras de progresso, círculos, marcas de seleção ou indicadores de etapas são excelentes maneiras de indicar quando uma tarefa foi concluída. Não se esqueça de que quanto mais sentimentos positivos a pessoa que usa o seu produto associar a ele, maior a probabilidade de ela voltar.",
         "leiaMais":"https://uxdesign.cc/endowed-progress-effect-give-your-users-a-head-start-97d52d8b0396",
         "asset":"Efeito_Zeigarnik",
         "exemplo":"zeigarnik",


### PR DESCRIPTION
- Updated all explanation texts from the front of the cards with the revised content.
- Also deleted the apostrophes from the names of some of the laws, such as "Lei de Fitt's", which is now "Lei de Fitt", as it should be in Portuguese.
- Added the missed accent to Prägnanz, as it is a German word and thus should be written as the original.

- ATTENTION: Will need to open a new branch to solve the following issue: search doesn't recognize words if the user doesn't type the accent. Examples are: "Estética" or "Prägnanz". Search bar doesn't recognize the word if it is spelled without the proper accent.